### PR TITLE
OAUTH2

### DIFF
--- a/FixFlow.Server/FixFlow.Server.csproj
+++ b/FixFlow.Server/FixFlow.Server.csproj
@@ -11,7 +11,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Facebook" Version="8.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="8.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="8.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.SpaProxy">
       <Version>8.*-*</Version>

--- a/FixFlow.Server/Program.cs
+++ b/FixFlow.Server/Program.cs
@@ -47,6 +47,21 @@ builder.Services.AddAuthentication(options =>
         ValidAudience = builder.Configuration["Jwt:Audience"],
         IssuerSigningKey = verifiedIssuerSigningKey
     };
+})
+.AddFacebook(options =>
+{
+    options.AppId = "client";
+    options.AppSecret = "secret";
+})
+.AddGoogle(options =>
+{
+    options.ClientId = "client";
+    options.ClientSecret = "secret";
+})
+.AddMicrosoftAccount(options =>
+{
+    options.ClientId = "";
+    options.ClientSecret = "secret";
 });
 
 builder.Services.AddAuthorization();


### PR DESCRIPTION
Let Clients register themselves with OAUTH2

Employees will still need to be added via normal email, until we figure how to handle more people joining that easily, in hopes to encourage more business to join our service