### PR TITLE
Initial Migration issues | 'Soft-Delete' feature removed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,9 +50,9 @@ dist-ssr
 /frontend/node_modules/
 
 # .NET WebAPI specific rules
-/webapi/Migrations/
-/webapi/bin/
-/webapi/obj/
+/FixFlow.Server/Migrations/
+/FixFlow.Server/bin/
+/FixFlow.Server/obj/
 
 # .NET Core
 project.lock.json

--- a/FixFlow.Server/Controllers/Users/ClientController.cs
+++ b/FixFlow.Server/Controllers/Users/ClientController.cs
@@ -44,7 +44,7 @@ public class ClientController : ControllerBase
         var client = await _userManager.FindByIdAsync(Id);
         if (client == null)
         {
-            client = await _context.Clients.IgnoreQueryFilters().FirstOrDefaultAsync(x => x.Id == Id);
+            client = await _context.Clients.FirstOrDefaultAsync(x => x.Id == Id);
         }
         if (client == null)
         {
@@ -117,7 +117,7 @@ public class ClientController : ControllerBase
         if (!string.IsNullOrWhiteSpace(clientRegister.PhoneNumber))
         {
 
-            var existingPhone = _context.Clients.IgnoreQueryFilters().Where(c => c.PhoneNumber == clientRegister.PhoneNumber);
+            var existingPhone = _context.Clients.Where(c => c.PhoneNumber == clientRegister.PhoneNumber);
             if (existingPhone != null)
             {
                 return BadRequest("PhoneNumber already registered!");
@@ -132,7 +132,7 @@ public class ClientController : ControllerBase
         if (!string.IsNullOrWhiteSpace(clientRegister.CPF))
         {
 
-            var existingCPF = _context.Clients.IgnoreQueryFilters().Where(c => c.CPF == clientRegister.CPF);
+            var existingCPF = _context.Clients.Where(c => c.CPF == clientRegister.CPF);
             if (existingCPF != null)
             {
                 return BadRequest("CPF already registered!");
@@ -149,7 +149,7 @@ public class ClientController : ControllerBase
             var existingEmail = await _userManager.FindByEmailAsync(clientRegister.Email);
             if (existingEmail == null)
             {
-                existingEmail = await _context.Clients.IgnoreQueryFilters().FirstOrDefaultAsync(x => x.Email == clientRegister.Email);
+                existingEmail = await _context.Clients.FirstOrDefaultAsync(x => x.Email == clientRegister.Email);
             }
             if (existingEmail != null)
             {
@@ -197,7 +197,7 @@ public class ClientController : ControllerBase
 
         if (existingClient.CPF != upClient.CPF)
         {
-            var existingCPF = _context.Clients.IgnoreQueryFilters().Where(x => x.CPF == upClient.CPF);
+            var existingCPF = _context.Clients.Where(x => x.CPF == upClient.CPF);
             if (existingCPF.Any())
             {
                 return BadRequest("CPF taken");
@@ -210,7 +210,7 @@ public class ClientController : ControllerBase
 
         if (existingClient.UserName != upClient.UserName)
         {
-            var existingUsername = _context.Clients.IgnoreQueryFilters().Where(x => x.UserName == upClient.UserName);
+            var existingUsername = _context.Clients.Where(x => x.UserName == upClient.UserName);
             if (existingUsername.Any())
             {
                 return BadRequest("Username already exists");
@@ -223,7 +223,7 @@ public class ClientController : ControllerBase
 
         if (existingClient.PhoneNumber != upClient.PhoneNumber)
         {
-            var existingPhonenumber = _context.Clients.IgnoreQueryFilters().Where(x => x.PhoneNumber == upClient.PhoneNumber);
+            var existingPhonenumber = _context.Clients.Where(x => x.PhoneNumber == upClient.PhoneNumber);
             if (existingPhonenumber.Any())
             {
                 return BadRequest("PhoneNumber taken");
@@ -264,7 +264,7 @@ public class ClientController : ControllerBase
             return BadRequest("Client does not Exist!");
         }
 
-        client.isDeleted = true;
+        await _userManager.DeleteAsync(client);
 
         await _context.SaveChangesAsync();
 

--- a/FixFlow.Server/Controllers/Users/EmployeeController.cs
+++ b/FixFlow.Server/Controllers/Users/EmployeeController.cs
@@ -44,7 +44,7 @@ public class EmployeeController : ControllerBase
         var employee = await _userManager.FindByIdAsync(Id);
         if (employee == null)
         {
-            employee = await _context.Employees.IgnoreQueryFilters().FirstOrDefaultAsync(x => x.Id == Id);
+            employee = await _context.Employees.FirstOrDefaultAsync(x => x.Id == Id);
         }
         if (employee == null)
         {
@@ -117,20 +117,20 @@ public class EmployeeController : ControllerBase
         var existingEmail = await _userManager.FindByEmailAsync(EmployeeDto.Email);
         if (existingEmail == null)
         {
-            existingEmail = await _context.Employees.IgnoreQueryFilters().FirstOrDefaultAsync(x => x.Email == EmployeeDto.Email);
+            existingEmail = await _context.Employees.FirstOrDefaultAsync(x => x.Email == EmployeeDto.Email);
         }
         if (existingEmail != null)
         {
             return BadRequest("Email already registered!");
         }
 
-        var existingCPF = _context.Employees.IgnoreQueryFilters().Where(c => c.CPF == EmployeeDto.CPF);
+        var existingCPF = _context.Employees.Where(c => c.CPF == EmployeeDto.CPF);
         if (existingCPF != null)
         {
             return BadRequest("CPF already registered!");
         }
 
-        var existingPhone = _context.Employees.IgnoreQueryFilters().Where(c => c.PhoneNumber == EmployeeDto.PhoneNumber);
+        var existingPhone = _context.Employees.Where(c => c.PhoneNumber == EmployeeDto.PhoneNumber);
         if (existingPhone != null)
         {
             return BadRequest("PhoneNumber already registered!");
@@ -163,7 +163,7 @@ public class EmployeeController : ControllerBase
         var existingEmployee = await _userManager.FindByIdAsync(upEmployee.Id);
         if (existingEmployee == null)
         {
-            existingEmployee = await _context.Employees.IgnoreQueryFilters().FirstOrDefaultAsync(x => x.Id == upEmployee.Id);
+            existingEmployee = await _context.Employees.FirstOrDefaultAsync(x => x.Id == upEmployee.Id);
         }
         if (existingEmployee == null)
         {
@@ -172,7 +172,7 @@ public class EmployeeController : ControllerBase
 
         if (existingEmployee.CPF != upEmployee.CPF)
         {
-            var existingCPF = _context.Clients.IgnoreQueryFilters().Where(x => x.CPF == upEmployee.CPF);
+            var existingCPF = _context.Clients.Where(x => x.CPF == upEmployee.CPF);
             if (existingCPF.Any())
             {
                 return BadRequest("CPF taken");
@@ -185,7 +185,7 @@ public class EmployeeController : ControllerBase
 
         if (existingEmployee.UserName != upEmployee.UserName)
         {
-            var existingUsername = _context.Clients.IgnoreQueryFilters().Where(x => x.UserName == upEmployee.UserName);
+            var existingUsername = _context.Clients.Where(x => x.UserName == upEmployee.UserName);
             if (existingUsername.Any())
             {
                 return BadRequest("Username already exists");
@@ -198,7 +198,7 @@ public class EmployeeController : ControllerBase
 
         if (existingEmployee.PhoneNumber != upEmployee.PhoneNumber)
         {
-            var existingPhonenumber = _context.Clients.IgnoreQueryFilters().Where(x => x.PhoneNumber == upEmployee.PhoneNumber);
+            var existingPhonenumber = _context.Clients.Where(x => x.PhoneNumber == upEmployee.PhoneNumber);
             if (existingPhonenumber.Any())
             {
                 return BadRequest("PhoneNumber taken");
@@ -239,7 +239,7 @@ public class EmployeeController : ControllerBase
             return BadRequest("Employee does not Exist!");
         }
 
-        employee.isDeleted = true;
+        await _userManager.DeleteAsync(employee);
 
         await _context.SaveChangesAsync();
 

--- a/FixFlow.Server/Controllers/Users/EmployeeController.cs
+++ b/FixFlow.Server/Controllers/Users/EmployeeController.cs
@@ -37,14 +37,14 @@ public class EmployeeController : ControllerBase
     /// <response code="404">If there is none with the given Id</response>
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<EmployeeDTO>))]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    [HttpGet("{id}")]
-    public async Task<IActionResult> ReadEmployee(string id)
+    [HttpGet("{Id}")]
+    public async Task<IActionResult> ReadEmployee(string Id)
     {
 
-        var employee = await _userManager.FindByIdAsync(id);
+        var employee = await _userManager.FindByIdAsync(Id);
         if (employee == null)
         {
-            employee = await _context.Employees.IgnoreQueryFilters().FirstOrDefaultAsync(x => x.Id == id);
+            employee = await _context.Employees.IgnoreQueryFilters().FirstOrDefaultAsync(x => x.Id == Id);
         }
         if (employee == null)
         {
@@ -114,8 +114,6 @@ public class EmployeeController : ControllerBase
     public async Task<IActionResult> CreateEmployee([FromBody] EmployeeRegister EmployeeDto)
     {
 
-        DeleteInactiveEmployees();
-
         var existingEmail = await _userManager.FindByEmailAsync(EmployeeDto.Email);
         if (existingEmail == null)
         {
@@ -161,8 +159,6 @@ public class EmployeeController : ControllerBase
     [HttpPatch]
     public async Task<IActionResult> UpdateEmployee([FromBody] EmployeeRegister upEmployee)
     {
-
-        DeleteInactiveEmployees();
 
         var existingEmployee = await _userManager.FindByIdAsync(upEmployee.Id);
         if (existingEmployee == null)
@@ -233,11 +229,11 @@ public class EmployeeController : ControllerBase
     /// <response code="400">Employee not found</response>
     [ProducesResponseType(StatusCodes.Status204NoContent, Type = typeof(EmployeeDTO))]
     [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(string))]
-    [HttpDelete("{id}")]
-    public async Task<IActionResult> DeleteEmployee(string id)
+    [HttpDelete("{Id}")]
+    public async Task<IActionResult> DeleteEmployee(string Id)
     {
 
-        var employee = await _userManager.FindByIdAsync(id);
+        var employee = await _userManager.FindByIdAsync(Id);
         if (employee == null)
         {
             return BadRequest("Employee does not Exist!");
@@ -248,18 +244,5 @@ public class EmployeeController : ControllerBase
         await _context.SaveChangesAsync();
 
         return NoContent();
-    }
-
-    public void DeleteInactiveEmployees()
-    {
-
-        var cutoffDate = DateTime.UtcNow.AddDays(-90);
-        var usersToDelete = _userManager.Users.Where(u => u.LastLogin < cutoffDate);
-
-        foreach (var user in usersToDelete)
-        {
-            user.isDeleted = true;
-        }
-
     }
 }

--- a/FixFlow.Server/Data/ServerContext.cs
+++ b/FixFlow.Server/Data/ServerContext.cs
@@ -15,9 +15,6 @@ public class ServerContext : IdentityDbContext
     protected override void OnModelCreating(ModelBuilder builder)
     {
         base.OnModelCreating(builder);
-
-        builder.Entity<Employee>().HasQueryFilter(x => x.isDeleted == false); //Only Read those NOT DELETED
-        builder.Entity<Client>().HasQueryFilter(x => x.isDeleted == false);
     }
 
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)

--- a/FixFlow.Server/Data/ServerContext.cs
+++ b/FixFlow.Server/Data/ServerContext.cs
@@ -22,7 +22,7 @@ public class ServerContext : IdentityDbContext
         base.OnConfiguring(optionsBuilder);
 
         optionsBuilder.UseMySql(
-            "Server=localhost;port=3306;Database=mysql;User=lendacerda;Password=xpvista7810;",
+            "Server=localhost;port=3306;Database=fixflow;User=lendacerda;Password=xpvista7810;",
             new MariaDbServerVersion(new Version(10, 5, 11)));
     }
 

--- a/FixFlow.Server/Models/Appointments/AptLog.cs
+++ b/FixFlow.Server/Models/Appointments/AptLog.cs
@@ -16,6 +16,12 @@ public class AptLog
     public float Price { get; set; }
     public string Observation { get; set; } = string.Empty;
 
+    public AptLog()
+    {
+        Id = string.Empty;
+        ClientId = string.Empty;
+    }
+
     public AptLog(string _clientId, float _price)
     {
         Id = new Guid().ToString();

--- a/FixFlow.Server/Models/Appointments/AptLog.cs
+++ b/FixFlow.Server/Models/Appointments/AptLog.cs
@@ -1,16 +1,19 @@
+using System.ComponentModel.DataAnnotations;
 using Server.Models.Utils;
 namespace Server.Models.Appointments;
 
 public class AptLog
 {
     public string Id { get; set; }
+
+    [Required]
     public string ClientId { get; set; }
 
     public string ScheduleId { get; set; } = string.Empty;
     public CompletedStatus Status { get; set; }
 
-    public float Price { get; set; }
     public DateTime DateTime { get; set; }
+    public float Price { get; set; }
     public string Observation { get; set; } = string.Empty;
 
     public AptLog(string _clientId, float _price)

--- a/FixFlow.Server/Models/Appointments/AptReminder.cs
+++ b/FixFlow.Server/Models/Appointments/AptReminder.cs
@@ -13,6 +13,13 @@ public class AptReminder
 
     public DateTime dateTime { get; set; }
 
+    public AptReminder()
+    {
+        Id = string.Empty;
+        ClientId = string.Empty;
+        previousAppointmentId = string.Empty;
+    }
+
     public AptReminder(string _clientId, string _prevAppoint)
     {
         Id = new Guid().ToString();

--- a/FixFlow.Server/Models/Appointments/AptReminder.cs
+++ b/FixFlow.Server/Models/Appointments/AptReminder.cs
@@ -1,8 +1,12 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace Server.Models.Appointments;
 
 public class AptReminder
 {
     public string Id { get; set; }
+
+    [Required]
     public string ClientId { get; set; }
 
     public string previousAppointmentId { get; set; }

--- a/FixFlow.Server/Models/Appointments/AptSchedule.cs
+++ b/FixFlow.Server/Models/Appointments/AptSchedule.cs
@@ -15,6 +15,12 @@ public class AptSchedule
     public float Price { get; set; }
     public string Observation { get; set; } = string.Empty;
 
+    public AptSchedule()
+    {
+        Id = string.Empty;
+        ClientId = string.Empty;
+    }
+
     public AptSchedule(string clientId, DateTime _dateTime)
     {
         Id = new Guid().ToString();

--- a/FixFlow.Server/Models/Appointments/AptSchedule.cs
+++ b/FixFlow.Server/Models/Appointments/AptSchedule.cs
@@ -1,14 +1,18 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace Server.Models.Appointments;
 
 public class AptSchedule
 {
     public string Id { get; set; }
+
+    [Required]
     public string ClientId { get; set; }
 
     public string reminderId { get; set; } = string.Empty;
 
-    public float Price { get; set; }
     public DateTime DateTime { get; set; }
+    public float Price { get; set; }
     public string Observation { get; set; } = string.Empty;
 
     public AptSchedule(string clientId, DateTime _dateTime)

--- a/FixFlow.Server/Models/Client.cs
+++ b/FixFlow.Server/Models/Client.cs
@@ -10,8 +10,6 @@ public class Client : IdentityUser
 
     public string additionalNote { get; set; }
 
-    public bool isDeleted { get; set; } = false;
-
     public Client()
     {
         CreatedDate = DateTime.Now;

--- a/FixFlow.Server/Models/Employee.cs
+++ b/FixFlow.Server/Models/Employee.cs
@@ -11,8 +11,6 @@ public class Employee : IdentityUser
 
     public float salary { get; set; }
 
-    public bool isDeleted { get; set; } = false;
-
     public Employee()
     {
         CreatedDate = DateTime.Now;

--- a/FixFlow.Server/appsettings.json
+++ b/FixFlow.Server/appsettings.json
@@ -7,7 +7,7 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "DefaultConnection": "Server=localhost;port=3306;Database=mysql;User=lendacerda;Password=xpvista7810;"
+    "DefaultConnection": "Server=localhost;port=3306;Database=fixflow;User=lendacerda;Password=xpvista7810;"
   },
   "Jwt": {
     "Issuer": "FixFlow",

--- a/FixFlow.Server/appsettings.json
+++ b/FixFlow.Server/appsettings.json
@@ -7,11 +7,10 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "DefaultConnection": "Server=localhost;port=3306;Database=mysql;User=lendacerda;Password=xpvista7810;",
-    "MongoDbConnection": "mongodb://localhost:27017/mongo_db"
+    "DefaultConnection": "Server=localhost;port=3306;Database=mysql;User=lendacerda;Password=xpvista7810;"
   },
   "Jwt": {
-    "Issuer": "CaloriesBurningApp",
+    "Issuer": "FixFlow",
     "Audience": "user",
     "SecretKey": "xpvista7810"
   }

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 **Technical aspects**
 
-Everything is CRUDed via an ASP.NET Core JSON WebApi. The webapp uses Token Authentication and Authorization
-The Users database is in MySQL, and the Appointments are saved in MongoDB
+The BackEnd is entirely a ASP.NET Core WebApi which handles HTTP CRUD requests to a MySQL database
+Authentication, Authorization, Validation and Rate Limitation middlewares are implemented
+We are using Tokens for this one
 
-On the Front-End, we are using a React with Typescript project. Everything there is done via http requests. Glad to be using a Token on this
+On the Front-End, we are using a React with Typescript project using Vite
 
 ---
 
@@ -18,11 +19,12 @@ Once you have it, download the 'mysql' docker image:
 
 Then, get the MySQL container online
 
-`docker run -d -p 3306:3306 --name mysql_container -e MYSQL_ROOT_PASSWORD=xpvista7810 -e MYSQL_DATABASE=fixflow -e MYSQL_USER=lendacerda -e MYSQL_PASSWORD=xpvista7810 mysql`
+`docker run -d -p 3306:3306 --name fixflow -e MYSQL_ROOT_PASSWORD=xpvista7810 -e MYSQL_DATABASE=fixflow -e MYSQL_USER=lendacerda -e MYSQL_PASSWORD=xpvista7810 mysql`
 
-And the MongoDB
+At the MySQL terminal, you'll need to Grant \* PRIVILEGES to the 'lendacerda' User
 
-`docker run --name mongo_db -d -p 27017:27017 mongo`
+`GRANT ALL PRIVILEGES ON mysql.* TO 'lendacerda'@'%';`
+`FLUSH PRIVILEGES;`
 
 Than, get into the Server folder
 


### PR DESCRIPTION
ConnectionString and Setup instructions:

The initial migration wasn't running. Initially thought the problem was ForeignKeys, hence the name of the branch

The problem was the connectionString, and granting privileges at MySQL

I updated the string, and the JWT Configuration Issuer while i was at it [both at the appsettings.json]
And the instructions at the README.md

- - - - -

We were using Global Query Filters for implementing Soft-Delete of Client and Employees. Both classes inherit from IdentityUser, which brings great EF Core suppor

The issue was, [Global Query Filters](https://learn.microsoft.com/en-us/ef/core/querying/filters#limitations) only work for the root Entity Type of an inheritance hierarchy. Dropping IdentityUser is off the table

Soft-Delete will require a more complex implementation, and the code, as is, is working fine for standard deletion